### PR TITLE
Add keyboard code for swiss mbp16

### DIFF
--- a/mac/bundle/qwerty-fr.bundle/Contents/Resources/qwerty-fr.keylayout
+++ b/mac/bundle/qwerty-fr.bundle/Contents/Resources/qwerty-fr.keylayout
@@ -15,6 +15,7 @@
         <layout first="27" last="28" mapSet="ANSI" modifiers="commonModifiers"/>
         <layout first="37" last="37" mapSet="ANSI" modifiers="commonModifiers"/>
         <layout first="40" last="40" mapSet="ANSI" modifiers="commonModifiers"/>
+        <layout first="43" last="43" mapSet="ISO" modifiers="commonModifiers"/>
         <layout first="195" last="195" mapSet="ANSI" modifiers="commonModifiers"/>
         <layout first="198" last="198" mapSet="ANSI" modifiers="commonModifiers"/>
         <layout first="204" last="204" mapSet="ANSI" modifiers="commonModifiers"/>


### PR DESCRIPTION
I've recently installed this awesome layout, but noticed the key left to the shift key wasn't working properly.
I then found https://github.com/qwerty-fr/qwerty-fr/issues/26 and went down a small hole to find my own keyboard's id  (Macbook Pro M1 16, Swiss QWERTZ ISO layout).
Seems to work on my system now, but no idea if this will work for any other M1 MBP16 ISO layouts.
For reference, I used this Swift snippet to get the code:
```Swift                                                                                                                                                                                                 
import CoreGraphics                                                                                                                                                                                     
                                                                                                                                                                                                        
let source = CGEventSource(stateID: .hidSystemState)                                                                                                                                                    
let keyboardType = source?.keyboardType                                                                                                                                                                 
                                                                                                                                                                                                       
print(keyboardType)                                                                                                                                                                                     
```