### PR TITLE
README — Add "Input Sources" step to Mac instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,13 +64,13 @@ If [homebrew]([url](https://brew.sh/)) is installed on your Mac, you can simply 
 ```
 brew install qwerty-fr
 ```
-Then to `System Preferences` → `Keyboard`, click `+`, scroll down to `Others` and add `qwerty-fr`. Then restart macOS.
+Then to `System Preferences` → `Keyboard` → `Input Sources`, click `+`, scroll down to `Others` and add `qwerty-fr`. Then restart macOS.
 
 **Automatic install**:
 
 - Download the [QWERTY-fr layout](https://github.com/qwerty-fr/qwerty-fr/releases/latest) PKG.
 - Do a right click on it and then click on `Open`. Follow the installation process.
-- Go to `System Preferences` → `Keyboard`, click `+`, scroll down to `Others` and add `qwerty-fr`.
+- Go to `System Preferences` → `Keyboard` → `Input Sources`, scroll down to `Others` and add `qwerty-fr`.
 - Restart macOS (if you don't some characters won't work).
 
 **Manual install**:
@@ -78,7 +78,7 @@ Then to `System Preferences` → `Keyboard`, click `+`, scroll down to `Others` 
 - Download the [QWERTY-fr layout](https://github.com/qwerty-fr/qwerty-fr/releases/latest) ZIP file and extract **qwerty-fr.bundle** to:
   - `/Library/Keyboard Layouts/` to install for all users.
   - `~/Library/Keyboard Layouts/` for user-local installation.
-- Go to `System Preferences` → `Keyboard`, click `+`, scroll down to `Others` and add `qwerty-fr`.
+- Go to `System Preferences` → `Keyboard` → `Input Sources`, click `+`, scroll down to `Others` and add `qwerty-fr`.
 - Restart macOS (if you don't some characters won't work).
 
 **✅ Protip**: On Apple keyboards the right <kbd>Option ⌥</kbd> key is often hard to access. You can use [Karabiner-Elements](https://pqrs.org/osx/karabiner/) to swap the right <kbd>Option ⌥</kbd> key with the right <kbd>Command ⌘</kbd> key. [Here is the rule](https://ke-complex-modifications.pqrs.org/#swap_right_cmd_with_right_option) you'll need to import in Karabiner-Elements. This makes it easier to type characters!


### PR DESCRIPTION
I noticed a missing navigation step to get to the list of input sources in Mac settings, maybe it's something that's recently been changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the instructions for installing a keyboard layout on macOS, focusing on clarity in the `System Preferences` steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->